### PR TITLE
change output format to svg of report option

### DIFF
--- a/lib/pwrake/report/parallelism.rb
+++ b/lib/pwrake/report/parallelism.rb
@@ -101,8 +101,8 @@ module Pwrake
 
       IO.popen("gnuplot","r+") do |f|
         f.puts "
-set terminal png
-set output '#{base}.png'
+set terminal svg
+set output '#{base}.svg'
 #set rmargin 10
 set title '#{base}'
 set xlabel 'time (sec)'
@@ -115,7 +115,7 @@ plot '#{fpara}' w l axis x1y1 title 'parallelism'
 "
       end
 
-      #puts "Parallelism plot: #{base}.png"
+      #puts "Parallelism plot: #{base}.svg"
     end
 
 
@@ -125,7 +125,7 @@ plot '#{fpara}' w l axis x1y1 title 'parallelism'
 
       density = exec_density(a)
 
-      fimg = base+'/parallelism.png'
+      fimg = base+'/parallelism.svg'
 
       n = a.size
       i = 0
@@ -155,7 +155,7 @@ plot '#{fpara}' w l axis x1y1 title 'parallelism'
       if system("which gnuplot >/dev/null 2>&1")
       IO.popen("gnuplot","r+") do |f|
         f.print "
-set terminal png
+set terminal svg
 set output '#{fimg}'
 #set rmargin 10
 set title '#{base}'
@@ -290,13 +290,13 @@ plot '-' w l axis x1y1 title 'parallelism', '-' w l axis x1y2 title 'exec/sec'
         end
       end
 
-      fimg = base+'/para_cmd.png'
+      fimg = base+'/para_cmd.svg'
 
       if system("which gnuplot >/dev/null 2>&1")
       IO.popen("gnuplot","r+") do |f|
         #begin f = $stdout
         f.print "
-set terminal png
+set terminal svg
 set output '#{fimg}'
 set title '#{base}'
 set xlabel 'time (sec)'
@@ -339,9 +339,9 @@ set ylabel 'parallelism'
     end
 
     def plot_parallelism_by_host(csvtable,base)
-      fpng = base+"/para_host.png"
+      fsvg = base+"/para_host.svg"
       data = read_time_by_host_from_csv(csvtable)
-      return fpng if data.size == 0
+      return fsvg if data.size == 0
 
       grid = []
       hosts = data.keys.sort
@@ -353,8 +353,8 @@ set ylabel 'parallelism'
       if system("which gnuplot >/dev/null 2>&1")
       IO.popen("gnuplot","r+") do |f|
         f.puts "
-set terminal png
-set output '#{fpng}'
+set terminal svg
+set output '#{fsvg}'
 #set rmargin 7
 set lmargin 16
 set pm3d map
@@ -385,7 +385,7 @@ set format y ''
         f.printf "e\n"
       end
       end
-      fpng
+      fsvg
     end
 
   end

--- a/lib/pwrake/report/report.rb
+++ b/lib/pwrake/report/report.rb
@@ -285,11 +285,11 @@ EOL
           command_list << cmd
         end
       end
-      hist_image = @base+"/hist.png"
+      hist_image = @base+"/hist.svg"
       if system("which gnuplot >/dev/null 2>&1")
       IO.popen("gnuplot","r+") do |f|
         f.puts "
-set terminal png # size 480,360
+set terminal svg # size 480,360
 set output '#{hist_image}'
 set ylabel 'histogram'
 set xlabel 'Execution time (sec)'

--- a/lib/pwrake/report/report_multi.rb
+++ b/lib/pwrake/report/report_multi.rb
@@ -9,7 +9,7 @@ module Pwrake
         r
       end
       @pattern = pattern
-      @elap_png = 'elap.png'
+      @elap_svg = 'elap.svg'
     end
 
     def report(stat_html)
@@ -29,7 +29,7 @@ module Pwrake
       end
       html << "</table>\n"
       html << "<h2>Elapsed time</h2>\n"
-      html << "<img src='./#{File.basename(@elap_png)}'  align='top'/></br>\n"
+      html << "<img src='./#{File.basename(@elap_svg)}'  align='top'/></br>\n"
 
       html << "<h2>Histogram of Execution time</h2>\n"
       html << report_histogram()
@@ -51,8 +51,8 @@ module Pwrake
       ymax = 10**(mid+wid)
       IO.popen("gnuplot","r+") do |f|
         f.puts "
-set terminal png size 640,480
-set output '#{@elap_png}'
+set terminal svg size 640,480
+set output '#{@elap_svg}'
 set xlabel 'ncore'
 set ylabel 'time (sec)'
 set yrange [#{ymin}:#{ymax}]
@@ -64,7 +64,7 @@ plot #{a}/x,'-' w lp lw 2 ps 2 title 'elapsed time'
         end
         f.puts "e"
       end
-      puts "Ncore-time plot: "+@elap_png
+      puts "Ncore-time plot: "+@elap_svg
     end
 
     def report_histogram
@@ -81,7 +81,7 @@ plot #{a}/x,'-' w lp lw 2 ps 2 title 'elapsed time'
       end
 
       @cmd_rep.each_key do |cmd|
-        @images[cmd] = 'hist_'+cmd.gsub(/[\/.]/,'_')+'.png'
+        @images[cmd] = 'hist_'+cmd.gsub(/[\/.]/,'_')+'.svg'
       end
       histogram_plot
       histogram_html
@@ -106,7 +106,7 @@ plot #{a}/x,'-' w lp lw 2 ps 2 title 'elapsed time'
       @cmd_rep.each do |cmd,cmd_rep|
         IO.popen("gnuplot","r+") do |f|
           f.puts "
-set terminal png # size 480,360
+set terminal svg # size 480,360
 set output '#{@images[cmd]}'
 set ylabel 'histogram'
 set xlabel 'Execution time (sec)'
@@ -139,7 +139,7 @@ set title '#{cmd}'"
       @cmd_rep.each do |cmd,cmd_rep|
         IO.popen("gnuplot","r+") do |f|
           f.puts "
-set terminal png # size 480,360
+set terminal svg # size 480,360
 set output '#{@images[cmd]}'
 set nohidden3d
 set palette rgb 33,13,10


### PR DESCRIPTION
reportオプションの機能変更の提案です。
現在reportオプション指定時に作成される画像の出力形式はpngですが、以下のようなエラーが出力されるので出力形式をsvgに変更しました。

> gnuplot> set terminal png
>                       ^
>          line 0: unknown or ambiguous terminal type; type just 'set terminal' for a list
> 
> WARNING: Plotting with an 'unknown' terminal.
> No output will be generated. Please select a terminal with 'set terminal'.
